### PR TITLE
add secret equality

### DIFF
--- a/src/clj/exoscale/cloak.clj
+++ b/src/clj/exoscale/cloak.clj
@@ -5,7 +5,13 @@
             [clojure.spec.alpha :as s]))
 
 (deftype Secret [x]
-  Object (toString [_] "<< cloaked >>")
+  Object
+  (toString [_] "<< cloaked >>")
+  (equals [this object]
+    (and (instance? Secret object)
+         (= x (.-x ^Secret object))))
+  (hashCode [this]
+    (.hashCode x))
   clojure.lang.IDeref
   (deref [this] x)
   clojure.lang.IPending

--- a/test/exoscale/cloak/test/core_test.clj
+++ b/test/exoscale/cloak/test/core_test.clj
@@ -40,3 +40,16 @@
 
 (deftest gen-test
   (is (every? secret/secret? (map first (s/exercise ::secret/secret)))))
+
+(deftest secret-equality
+  (testing "equality must succeed for same secret value"
+    (let [x (rand-int 1000)
+          s1 (secret/mask x)
+          s2 (secret/mask x)]
+      (is (= s1 s2))
+      (is (= (.hashCode s1) (.hashCode s2)))))
+  (testing "equality must fail for different secret value"
+    (let [s1 (secret/mask "foo")
+          s2 (secret/mask "bar")]
+      (is (not= s1 s2))
+      (is (not= (.hashCode s1) (.hashCode s2))))))


### PR DESCRIPTION
currently cloak equality is using reference. 
this PR will give ability to compare using the cloak value

```
before
(= (cloak/mask 1) (cloak/mask 1)) ; => false

after
(= (cloak/mask 1) (cloak/mask 1)) ; => true
```


do you think it is a security risk ?