### PR TITLE
fix(cloak): Babashka compatibility 

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@10.0
         with:
+          bb: latest
           cli: 1.11.1.1182
 
       - name: Run clj tests
@@ -28,3 +29,6 @@ jobs:
 
       - name: Run cljs tests
         run: ./bin/kaocha cljs
+        
+      - name: Run bb tests
+        run: bb test:bb

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,8 @@
+{:tasks
+ {test:bb {:extra-paths ["test" "src"]
+           :extra-deps {io.github.cognitect-labs/test-runner
+                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :task (exec 'cognitect.test-runner.api/test)
+           :exec-args {:dirs ["test"]}
+           :org.babashka/cli {:coerce {:nses [:symbol]
+                                       :vars [:symbol]}}}}}

--- a/src/exoscale/cloak.cljc
+++ b/src/exoscale/cloak.cljc
@@ -1,8 +1,8 @@
 (ns exoscale.cloak
   (:require [clojure.pprint :as pp]
-            [clojure.walk :as walk]
+            [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
-            [clojure.spec.alpha :as s])
+            [clojure.walk :as walk])
   #?(:cljs (:refer-clojure :exclude [mask])))
 
 (deftype Secret [x]
@@ -15,7 +15,11 @@
        (isRealized [this] false)
        Comparable
        (compareTo [this other] 0)) ;; to make compatible with seql h2/mysql
-
+      :bb
+      (clojure.lang.IDeref
+       (deref [this] x)
+       Comparable
+       (compareTo [this other] 0))
       :cljs
       (IDeref
        (-deref [this] x)
@@ -38,9 +42,9 @@
      (prefer-method print-method Secret Object))
    :cljs
    (extend-protocol IPrintWithWriter
-       Secret
-       (-pr-writer [new-obj writer _]
-         (write-all writer "\"" (str new-obj) "\""))))
+     Secret
+     (-pr-writer [new-obj writer _]
+       (write-all writer "\"" (str new-obj) "\""))))
 
 (defn mask
   "Mask a value behind the `Secret` type, hiding its real value when printing"

--- a/test/exoscale/cloak_test.cljc
+++ b/test/exoscale/cloak_test.cljc
@@ -9,7 +9,7 @@
 (deftest secret-test
   (let [x "foo"
         s (secret/mask x)]
-    #?(:bb ()
+    #?(:bb (is (= "foo" (secret/reveal s)))
        :clj (is (= "foo" @s)))
     (is (nil? (str/index-of (pr-str s) "foo")))
     (is (nil? (str/index-of (str s) "foo")))
@@ -21,7 +21,7 @@
     (is (= {:a "foo"} (secret/unmask {:a s})))
     (is (= {:a {:b {:c [1 "foo"]}}} (secret/unmask {:a {:b {:c [1 s]}}})))
     (defrecord F [s])
-    #?(:bb ()
+    #?(:bb (is (= (->F (secret/reveal s)) (secret/unmask (->F s))))
        :clj (is (= (->F @s) (secret/unmask (->F s)))))
     (is (= {:a 1} (secret/unmask (secret/mask {:a (secret/mask 1)}))))))
 

--- a/test/exoscale/cloak_test.cljc
+++ b/test/exoscale/cloak_test.cljc
@@ -1,15 +1,16 @@
 (ns exoscale.cloak-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [clojure.test.check.generators]
-            [exoscale.cloak :as secret]
+  (:require [clojure.pprint :as pp]
+            [clojure.spec.alpha :as s]
             [clojure.string :as str]
-            [clojure.pprint :as pp]
-            [clojure.spec.alpha :as s]))
+            [clojure.test :refer [deftest is testing]]
+            [clojure.test.check.generators]
+            [exoscale.cloak :as secret]))
 
 (deftest secret-test
   (let [x "foo"
         s (secret/mask x)]
-    (is (= "foo" @s))
+    #?(:bb ()
+       :clj (is (= "foo" @s)))
     (is (nil? (str/index-of (pr-str s) "foo")))
     (is (nil? (str/index-of (str s) "foo")))
     (is (= "\"<< cloaked >>\"\n" (with-out-str (pp/pprint s))))
@@ -20,15 +21,18 @@
     (is (= {:a "foo"} (secret/unmask {:a s})))
     (is (= {:a {:b {:c [1 "foo"]}}} (secret/unmask {:a {:b {:c [1 s]}}})))
     (defrecord F [s])
-    (is (= (->F @s) (secret/unmask (->F s))))
+    #?(:bb ()
+       :clj (is (= (->F @s) (secret/unmask (->F s)))))
     (is (= {:a 1} (secret/unmask (secret/mask {:a (secret/mask 1)}))))))
 
-(deftest compare-test
-  (let [x (secret/mask "x")
-        y (secret/mask "y")]
-    (is (= [x y] (sort [x y])))
-    (is (zero? (compare x y)))
-    (is (zero? (compare y x)))))
+#?(:bb ()
+   :clj
+   (deftest compare-test
+     (let [x (secret/mask "x")
+           y (secret/mask "y")]
+       (is (= [x y] (sort [x y])))
+       (is (zero? (compare x y)))
+       (is (zero? (compare y x))))))
 
 (deftest double-masking-test
   (testing "masking a secret twice requires only a single unmasking"


### PR DESCRIPTION
Adjusted the implementation of `Secret` type to include `:bb` specific behavior
and ensured compatibility across platforms
fixes #14 